### PR TITLE
[Feature] import more of the available meta-data during sync

### DIFF
--- a/includes/Controller/AddonController.php
+++ b/includes/Controller/AddonController.php
@@ -33,6 +33,23 @@ class AddonController extends AbstractController {
 		if (isset($constraints['extensionIds']) && $constraints['extensionIds']) {
 			$whereClause .= ' AND id IN ("' . implode('","', $constraints['extensionIds']) . '")';
 		}
+		if (isset($constraints['repositories']) && $constraints['repositories']) {
+			$whereClause .= ' AND repository_id IN ("' . implode('","', $constraints['repositories']) . '")';
+		}
+		if (isset($constraints['platforms']) && $constraints['platforms']) {
+			$platformClauses = array();
+			foreach ($constraints['platforms'] as $platform) {
+				$platformClauses[] = 'FIND_IN_SET ("' . $platform . '", platforms)';
+			}
+			$whereClause .= ' AND (' . implode(' OR ', $platformClauses) . ')';
+		}
+		if (isset($constraints['languages']) && $constraints['languages']) {
+			$langClauses = array();
+			foreach ($constraints['languages'] as $language) {
+				$langClauses[] = 'FIND_IN_SET ("' . $language . '", languages)';
+			}
+			$whereClause .= ' AND (' . implode(' OR ', $langClauses) . ')';
+		}
 
 		// execute queries
 		$limit = 40;

--- a/install/database.sql
+++ b/install/database.sql
@@ -48,8 +48,11 @@ CREATE TABLE IF NOT EXISTS `addon` (
   `broken` tinytext DEFAULT NULL,
   `deleted` tinyint(3) unsigned DEFAULT '0' NOT NULL,
   `repository_id` tinytext DEFAULT NULL,
+  `platforms` tinytext DEFAULT '',
+  `languages` tinytext DEFAULT '',
   PRIMARY KEY (`id`),
   KEY keyaddontype ( `extension_point` ( 60 ) , `content_types` ( 100 ) ),
+  KEY languages ( `languages` ( 60 ) ),
   KEY keyauthor ( `provider_name` ( 100 ) )
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/install/migrate_db.php
+++ b/install/migrate_db.php
@@ -16,13 +16,16 @@ $tables = array(
 				'content_types' => 'tinytext DEFAULT NULL',
 				'broken' => 'tinytext DEFAULT NULL',
 				'deleted' => 'tinyint(3) unsigned DEFAULT \'0\' NOT NULL',
-				'repository_id' => 'tinytext DEFAULT NULL'
+				'repository_id' => 'tinytext DEFAULT NULL',
+				'platforms' => 'tinytext DEFAULT \'\'',
+				'languages' => 'tinytext DEFAULT \'\'',
 			)
 		),
 		'keys' => array(
 			'add' => array(
 				'keyaddontype' => '( `extension_point` ( 60 ) , `content_types` ( 100 ) )',
-				'keyauthor' => '( `provider_name` ( 100 ) )'
+				'keyauthor' => '( `provider_name` ( 100 ) )',
+				'languages' => '( `languages` ( 60 ) )',
 			)
 		)
 	)


### PR DESCRIPTION
I noticed that we're not yet importing the platforms as well as the languag meta-tags from addons, but at least the platform info might be nice to have/show on the addon frontend, so I added them to the DB and syncscript. I also added the possibility to filter addons by these tags. That way we could create categories that list platform specific addons or list addons by Kodi version (using repo filter).

Feel free to merge if you think this would be nice to have.